### PR TITLE
Improve LAMMPS ==> GROMACS conversion

### DIFF
--- a/intermol/forces/abstract_pair.py
+++ b/intermol/forces/abstract_pair.py
@@ -7,7 +7,7 @@ class AbstractPair(object):
         self.pairtype = pairtype
 
     def __eq__(self, object):
-        if ((self.atom1 == object.atom1 and self.object2 == object.atom2) or (self.atom1 == object.atom2 and self.atom2 == object.atom1)):
+        if ((self.atom1 == object.atom1 and self.atom2 == object.atom2) or (self.atom1 == object.atom2 and self.atom2 == object.atom1)):
             return True
         else:
             return False

--- a/intermol/forces/abstract_pair.py
+++ b/intermol/forces/abstract_pair.py
@@ -7,7 +7,7 @@ class AbstractPair(object):
         self.type = type
 
     def __eq__(self, object):
-        if (self.atom1 == (object.atom1 or object.atom2)) and (self.atom2 == (object.atom2 or object.atom1)):
+        if ((self.atom1 == object.atom1 and self.object2 == object.atom2) or (self.atom1 == object.atom2 and self.atom2 == object.atom1)):
             return True
         else:
             return False

--- a/intermol/forces/abstract_pair.py
+++ b/intermol/forces/abstract_pair.py
@@ -1,10 +1,10 @@
 class AbstractPair(object):
-    __slots__ = ['atom1', 'atom2', 'type']
+    __slots__ = ['atom1', 'atom2', 'pairtype']
 
-    def __init__(self, atom1, atom2, type = None):
+    def __init__(self, atom1, atom2, pairtype = None):
         self.atom1 = atom1
         self.atom2 = atom2
-        self.type = type
+        self.pairtype = pairtype
 
     def __eq__(self, object):
         if ((self.atom1 == object.atom1 and self.object2 == object.atom2) or (self.atom1 == object.atom2 and self.atom2 == object.atom1)):
@@ -13,5 +13,5 @@ class AbstractPair(object):
             return False
 
     def __hash__(self):
-        return hash(tuple([self.atom1, self.atom2]))
+        return hash(tuple(sorted([self.atom1, self.atom2])))
 

--- a/intermol/gromacs_extension/gromacs_structure_parser.py
+++ b/intermol/gromacs_extension/gromacs_structure_parser.py
@@ -82,20 +82,24 @@ def writeStructure(filename):
     """
     lines = list()
     n = 0
+    res_offset = 0
+    res_offset_next = 0
     for moleculetype in System._sys._molecules.values():
         for molecule in moleculetype.moleculeSet:
             for atom in molecule._atoms:
-                if atom.name.isdigit():
-                    atom.name = "LMP_" + atom.name
+#                if atom.name.isdigit():
+#                    atom.name = "LMP_" + atom.name
                 n += 1
-                lines.append('%5d%-4s%6s%5d%13.8f%13.8f%13.8f%13.8f%13.8f%13.8f\n'
-                             % (atom.residue_index, atom.residue_name, atom.name, n,
+                lines.append('%5d%-5s%5s%5d%13.8f%13.8f%13.8f%13.8f%13.8f%13.8f\n'
+                             % (atom.residue_index + res_offset, atom.residue_name, atom.name, n,
                                 atom._position[0].in_units_of(units.nanometers)._value,
                                 atom._position[1].in_units_of(units.nanometers)._value,
                                 atom._position[2].in_units_of(units.nanometers)._value,
                                 atom._velocity[0].in_units_of(units.nanometers / units.picoseconds)._value,
                                 atom._velocity[1].in_units_of(units.nanometers / units.picoseconds)._value,
                                 atom._velocity[2].in_units_of(units.nanometers / units.picoseconds)._value))
+                res_offset_next = res_offset + atom.residue_index
+            res_offset = res_offset_next
     # print the box vector
     # check for rectangular; should be symmetric, so we don't have to check 6 values
     if (System._sys.box_vector[1, 0]._value == 0 and

--- a/intermol/gromacs_extension/gromacs_structure_parser.py
+++ b/intermol/gromacs_extension/gromacs_structure_parser.py
@@ -91,7 +91,7 @@ def writeStructure(filename):
 #                if atom.name.isdigit():
 #                    atom.name = "LMP_" + atom.name
                 n += 1
-                lines.append('%5d%-5s%5s%5d%13.8f%13.8f%13.8f%13.8f%13.8f%13.8f\n'
+                lines.append('%5d%-5s%5s%5d%12.6f%12.6f%12.6f%12.6f%12.6f%12.6f\n'
                              % (atom.residue_index + res_offset, atom.residue_name, atom.name, n,
                                 atom._position[0].in_units_of(units.nanometers)._value,
                                 atom._position[1].in_units_of(units.nanometers)._value,

--- a/intermol/gromacs_extension/gromacs_structure_parser.py
+++ b/intermol/gromacs_extension/gromacs_structure_parser.py
@@ -34,9 +34,10 @@ def readStructure(filename):
             molecule = molecules[n]
             for atom in molecule._atoms:
                 if lines[i]:
-                    atom.residue_index = int(lines[i][0:5])
-                    atom.residue_name = lines[i][5:10].strip()
-                    atom.name = lines[i][10:15].strip()
+# NOTE: These should already be defined (see gromacs_topology_parser)
+#                    atom.residue_index = int(lines[i][0:5])
+#                    atom.residue_name = lines[i][5:10].strip()
+#                    atom.name = lines[i][10:15].strip()
                     variables = (lines[i][20:]).split()
                     position = np.zeros([3], float) * units.nanometers
                     velocity = np.zeros([3], float) * units.nanometers / units.picoseconds

--- a/intermol/gromacs_extension/gromacs_topology_parser.py
+++ b/intermol/gromacs_extension/gromacs_topology_parser.py
@@ -1308,7 +1308,7 @@ class GromacsTopologyParser(object):
         # [ defaults ]
         lines.append('[ defaults ]\n')
         lines.append('; nbfunc        comb-rule       gen-pairs       fudgeLJ fudgeQQ\n')
-        lines.append('%d%16d%18s%20.4f%8.4f\n'
+        lines.append('%d%16d%18s%20.4g%8.4g\n'
                 % (System._sys.nonbonded_function,
                    System._sys.combination_rule,
                    System._sys.genpairs,
@@ -1336,7 +1336,7 @@ class GromacsTopologyParser(object):
                            atomtype.sigma.in_units_of(units.kilojoules_per_mole * units.nanometers**(6))._value,
                            atomtype.epsilon.in_units_of(units.kilojoules_per_mole * units.nanometers**(12))._value))
             elif System._sys.combination_rule in (2, 3):
-                lines.append('%-11s%5s%6d%18.8f%18.8f%5s%18.8e%18.8e\n'
+                lines.append('%-10s %-10s %4d %12.6f %9.3f %5s %16.6e %16.6e\n'
                         % (atomtype.atomtype,
                            atomtype.bondtype,
                            int(atomtype.atomic_number),
@@ -1388,7 +1388,7 @@ class GromacsTopologyParser(object):
 #                    atom._atomtype[0] = "LMP_" + atom._atomtype[0]
 
                 try:
-                    lines.append('%6d%18s%6d%8s%8s%6d%18.8f%18.8f%18s%18.8f%18.8f\n'
+                    lines.append('%6d %10s %6d %8s %8s %6d %12.6f %12.6f %10s %12.6f %12.6f\n'
                             % (count,
                                atom._atomtype[0],
                                atom.residue_index,
@@ -1401,7 +1401,7 @@ class GromacsTopologyParser(object):
                                atom._charge[1].in_units_of(units.elementary_charge)._value,
                                atom._mass[1].in_units_of(units.atomic_mass_unit)._value))
                 except:
-                    lines.append('%6d%18s%6d%8s%8s%6d%18.8f%18.8f\n'
+                    lines.append('%6d %10s %6d %8s %8s %6d %12.6f %12.6f\n'
                                  % (count,
                                     atom._atomtype[0],
                                     atom.residue_index,
@@ -1421,7 +1421,7 @@ class GromacsTopologyParser(object):
                 for bond in bondlist:
                     if isinstance(bond, Bond):
                         b_type = 1
-                        lines.append('%6d%7d%4d%18.8e%18.8e\n'
+                        lines.append('%6d %6d %3d %12.6f %16.6e\n'
                                 % (bond.atom1,
                                    bond.atom2,
                                    b_type,
@@ -1467,7 +1467,7 @@ class GromacsTopologyParser(object):
 
                     if isinstance(pair, AbstractPair):
                         p_type = 1
-                        lines.append('%6d%7d%4d\n'
+                        lines.append('%6d %6d %3d\n'
                                 % (pair.atom1,
                                    pair.atom2,
                                    p_type))
@@ -1483,10 +1483,10 @@ class GromacsTopologyParser(object):
 
                 anglelist = sorted(moleculeType.angleForceSet.itervalues(), key=lambda x: (x.atom1, x.atom2, x.atom3))
                 for angle in anglelist:
-                    atomindex = "%6d%7d%7d" % (angle.atom1,angle.atom2,angle.atom3)
+                    atomindex = "%6d %6d %6d" % (angle.atom1,angle.atom2,angle.atom3)
                     if isinstance(angle, Angle):
                         a_type = 1
-                        lines.append('%s%4d%18.8e%18.8e\n'
+                        lines.append('%s %3d %12.3f %12.6f\n'
                                 % (atomindex,
                                    a_type,
                                    angle.theta.in_units_of(units.degrees)._value,
@@ -1549,7 +1549,7 @@ class GromacsTopologyParser(object):
                         key=lambda x: (x.atom1, x.atom2, x.atom3, x.atom4))
                 for dihedral in dihedrallist:
                     # this atom index will be the same for all of types.
-                    atomindex = "%7d%7d%7d%7d" % (dihedral.atom1, dihedral.atom2,
+                    atomindex = "%6d %6d %6d %6d" % (dihedral.atom1, dihedral.atom2,
                             dihedral.atom3, dihedral.atom4)
                     if isinstance(dihedral, DihedralTrigDihedral):
                         # convienience array
@@ -1564,7 +1564,7 @@ class GromacsTopologyParser(object):
                                     else:
                                         raise ValueError("Found more than one nonzero "
                                                 "coefficient in improper trigonal dihedral!")
-                                    lines.append('%s%4d%18.8f%18.8f%6d\n'
+                                    lines.append('%s %3d %7.1f %17.6f %5d\n'
                                                  % (atomindex, 4,
                                                     dihedral.phi.in_units_of(units.degrees)._value,
                                                     coeff.in_units_of(units.kilojoules_per_mole)._value,
@@ -1578,7 +1578,7 @@ class GromacsTopologyParser(object):
                             if (dihedral.phi in [0*units.degrees, 180*units.degrees] and
                                     rb_coeffs[6]._value == 0):
                                 d_type = 3
-                                lines.append('%s%4d%18.8f%18.8f%18.8f%18.8f%18.8f%18.8f\n'
+                                lines.append('%s %3d %12.6f %12.6f %12.6f %12.6f %12.6f %12.6f\n'
                                              % (atomindex,
                                                 d_type,
                                                 rb_coeffs[0].in_units_of(units.kilojoules_per_mole)._value,

--- a/intermol/gromacs_extension/gromacs_topology_parser.py
+++ b/intermol/gromacs_extension/gromacs_topology_parser.py
@@ -1321,10 +1321,10 @@ class GromacsTopologyParser(object):
         lines.append(';type, bondtype, atomic_number, mass, charge, ptype, sigma, epsilon\n')
         atomtypelist = sorted(System._sys._atomtypes.itervalues(), key=lambda x: x.atomtype)
         for atomtype in atomtypelist:
-            if atomtype.atomtype.isdigit():
-                atomtype.atomtype = "LMP_" + atomtype.atomtype
-            if atomtype.bondtype.isdigit():
-                atomtype.bondtype = "LMP_" + atomtype.bondtype
+#            if atomtype.atomtype.isdigit():
+#                atomtype.atomtype = "LMP_" + atomtype.atomtype
+#            if atomtype.bondtype.isdigit():
+#                atomtype.bondtype = "LMP_" + atomtype.bondtype
             if System._sys.combination_rule == 1:
                 lines.append('%-11s%5s%6d%18.8f%18.8f%5s%18.8e%18.8e\n'
                         % (atomtype.atomtype,
@@ -1382,10 +1382,10 @@ class GromacsTopologyParser(object):
             molecule = moleculeType.moleculeSet[0]
             count = 1
             for atom in molecule._atoms:
-                if atom.name.isdigit():
-                    atom.name = "LMP_" + atom.name
-                if atom._atomtype[0].isdigit():
-                    atom._atomtype[0] = "LMP_" + atom._atomtype[0]
+#                if atom.name.isdigit():
+#                    atom.name = "LMP_" + atom.name
+#                if atom._atomtype[0].isdigit():
+#                    atom._atomtype[0] = "LMP_" + atom._atomtype[0]
 
                 try:
                     lines.append('%6d%18s%6d%8s%8s%6d%18.8f%18.8f%18s%18.8f%18.8f\n'

--- a/intermol/gromacs_extension/gromacs_topology_parser.py
+++ b/intermol/gromacs_extension/gromacs_topology_parser.py
@@ -1036,8 +1036,13 @@ class GromacsTopologyParser(object):
                         # we need to add a constrainted bonded forces as well between the atoms in these molecules.
                         # we assume the gromacs default of 1. O, 2. H, 3. H
                         # reference bond strength is 900 kj/mol, but doesn't really matter since constrainted.
-                        waterbondrefk = 900*units.kilojoules_per_mole * units.nanometers**(-2)
-                        wateranglerefk = 400*units.kilojoules_per_mole * units.degrees**(-2)
+                        #waterbondrefk = 900*units.kilojoules_per_mole * units.nanometers**(-2)
+                        #wateranglerefk = 400*units.kilojoules_per_mole * units.degrees**(-2)
+                        
+                        # From oplsaa.ff/tip3p.itp - JPT
+                        waterbondrefk = 502416.0 * units.kilojoules_per_mole * units.nanometers**(-2)
+                        wateranglerefk = 628.02 * units.kilojoules_per_mole * units.radians**(-2)
+
                         angle = 2.0 * math.asin(0.5 * float(split[3]) / float(split[2])) * units.radians
                         dOH = float(split[2]) * units.nanometers
 

--- a/intermol/gromacs_extension/gromacs_topology_parser.py
+++ b/intermol/gromacs_extension/gromacs_topology_parser.py
@@ -1413,7 +1413,7 @@ class GromacsTopologyParser(object):
                 count += 1
             lines.append('\n')
 
-            if moleculeType.bondForceSet:
+            if moleculeType.bondForceSet and not moleculeType.settles:
                 # [ bonds ]
                 lines.append('[ bonds ]\n')
                 lines.append(';   ai     aj funct  r               k\n')
@@ -1476,7 +1476,7 @@ class GromacsTopologyParser(object):
                         raise Exception("WriteError: found unsupported pair type")
                 lines.append('\n')
 
-            if moleculeType.angleForceSet:
+            if moleculeType.angleForceSet and not moleculeType.settles:
                 # [ angles ]
                 lines.append('[ angles ]\n')
                 lines.append(';   ai     aj     ak    funct   theta         cth\n')

--- a/intermol/gromacs_extension/gromacs_topology_parser.py
+++ b/intermol/gromacs_extension/gromacs_topology_parser.py
@@ -1641,11 +1641,13 @@ class GromacsTopologyParser(object):
             if moleculeType.exclusions:
                 # [ exclusions ]
                 lines.append('[ exclusions ]\n')
-                exclusionlist = sorted(moleculeType.exclusions.itervalues(), key=lambda x: (x.exclusions[0], x.exclusions[1]))
+                exclusionlist = sorted(moleculeType.exclusions.itervalues(), key=lambda x: x.exclusions[0])
                 for exclusion in exclusionlist:
-                    lines.append('%6s%6s\n'
-                                 % (exclusion.exclusions[0],
-                                    exclusion.exclusions[1]))
+                    lines.append('%-6d' % exclusion.exclusions[0])
+                    for i in range(1, len(exclusion.exclusions)):
+                        lines.append(' %-6d' % exclusion.exclusions[i]),
+                    lines.append('\n')
+
         # [ system ]
         lines.append('[ system ]\n')
         lines.append('%s\n' % (System._sys._name))

--- a/intermol/lammps_extension/lammps_parser.py
+++ b/intermol/lammps_extension/lammps_parser.py
@@ -66,19 +66,6 @@ class LammpsParser(object):
                     if keyword in parsable_keywords:
                         parsable_keywords[keyword](line.split())
 
-        self.RAD = units.radians
-        self.DEGREE = units.degrees
-        if self.unit_set == 'real':
-            self.DIST = units.angstroms
-            self.VEL = units.angstroms / units.femtosecond
-            self.ENERGY = units.kilocalorie / units.mole
-            self.MASS = units.grams / units.mole
-            self.CHARGE = units.elementary_charge
-            self.MOLE = units.mole
-        else:
-            raise Exception("Unsupported unit set specified in input file: "
-                    "{0}".format(self.unit_set))
-
     def read_data(self, data_file):
         """Reads a LAMMPS data file.
 
@@ -139,6 +126,19 @@ class LammpsParser(object):
         """ """
         assert(len(line) == 2), "Invalid units specified in input file."
         self.unit_set = line[1]
+
+        self.RAD = units.radians
+        self.DEGREE = units.degrees
+        if self.unit_set == 'real':
+            self.DIST = units.angstroms
+            self.VEL = units.angstroms / units.femtosecond
+            self.ENERGY = units.kilocalorie / units.mole
+            self.MASS = units.grams / units.mole
+            self.CHARGE = units.elementary_charge
+            self.MOLE = units.mole
+        else:
+            raise Exception("Unsupported unit set specified in input file: "
+                    "{0}".format(self.unit_set))
 
     def parse_atom_style(self, line):
         """

--- a/intermol/lammps_extension/lammps_parser.py
+++ b/intermol/lammps_extension/lammps_parser.py
@@ -58,6 +58,7 @@ class LammpsParser(object):
                 'improper_style': self.parse_improper_style,
                 'special_bonds': self.parse_special_bonds,
                 'read_data': self.parse_read_data}
+                'fix': self.parse_fix}
 
         with open(input_file, 'r') as input_lines:
             for line in input_lines:
@@ -282,6 +283,44 @@ class LammpsParser(object):
         else:
             logger.warn("Unsupported read_data arguments in input file.")
 
+    def parse_fix(self, line):
+        """ """
+        if len(line) > 3 and line[3] == 'shake':
+            parse_fix_shake(line)
+
+    def parse_fix_shake(self, line):
+        """ """
+        if line[2] != 'all':
+            logger.warn("Unsupported group-ID in fix shake command")
+            return            
+        if 'mol' in line:
+            logger.warn("Unsupported keyword 'mol' in fix shake command")
+            return
+        
+        if not self.shake_bond_types_i:
+            self.shake_bond_types_i = set()
+        if not self.shake_angle_types_i:
+            self.shake_angle_types_i = set()
+        if not self.shake_masses:
+            self.shake_masses = set()
+
+        line = line[7:]
+        for field in line:
+            if field == 't':
+                logger.warn("SHAKE 't' (atom type) constraints not yet supported: fix shake ignored.")
+                return
+            elif field == 'b':
+                container = self.shake_bond_types_i
+                str2num = int
+            elif field == 'a':
+                container = self.shake_angle_types_i
+                str2num = int
+            elif field == 'm':
+                container = self.shake_masses
+                str2num = float
+            else:
+                container.add(str2num(field))
+            
     def parse_box(self, line, dim):
         """Read box information from data file.
 

--- a/intermol/lammps_extension/lammps_parser.py
+++ b/intermol/lammps_extension/lammps_parser.py
@@ -545,7 +545,7 @@ class LammpsParser(object):
             fields = [int(field) for field in line.partition('#')[0].split()]
 
             new_bond_force = None
-            coeff_num = int(fields[1])
+            coeff_num = fields[1]
             # Bond
             if self.bond_types[coeff_num][0] == 'harmonic':
                 r = self.bond_types[coeff_num][2]
@@ -572,11 +572,11 @@ class LammpsParser(object):
             fields = [int(field) for field in line.partition('#')[0].split()]
 
             new_angle_force = None
-            coeff_num = int(fields[1])
+            coeff_num = fields[1]
             # Angle
             if self.angle_types[coeff_num][0] == 'harmonic':
-                theta = self.angle_types[int(fields[1])][2]
-                k = self.angle_types[int(fields[1])][1]
+                theta = self.angle_types[coeff_num][2]
+                k = self.angle_types[coeff_num][1]
                 new_angle_force = Angle(
                         fields[2], fields[3], fields[4],
                         theta, k)
@@ -623,10 +623,10 @@ class LammpsParser(object):
             fields = [int(field) for field in line.partition('#')[0].split()]
 
             new_dihed_force = None
-            coeff_num = int(fields[1])
+            coeff_num = fields[1]
             if  self.improper_types[coeff_num][0] == 'harmonic':
-                k = self.improper_types[fields[1]][1]
-                xi = self.improper_types[fields[1]][2]
+                k = self.improper_types[coeff_num][1]
+                xi = self.improper_types[coeff_num][2]
                 new_dihed_force = ImproperHarmonicDihedral(
                         fields[2], fields[3], fields[4], fields[5],
                         xi, k)

--- a/intermol/lammps_extension/lammps_parser.py
+++ b/intermol/lammps_extension/lammps_parser.py
@@ -207,14 +207,14 @@ class LammpsParser(object):
 
     def parse_bond_style(self, line):
         """ """
-        self.bond_style = set()
+        self.bond_style = []
         self.hybrid_bond_style = False
         if len(line) == 2:
-            self.bond_style.add(line[1])
+            self.bond_style.append(line[1])
         elif len(line) > 2 and line[1] == 'hybrid':
             self.hybrid_bond_style = True
             for style in line[2:]:
-                self.bond_style.add(style)
+                self.bond_style.append(style)
         else:
             raise ValueError("Invalid bond_style in input file!")
 

--- a/intermol/lammps_extension/lammps_parser.py
+++ b/intermol/lammps_extension/lammps_parser.py
@@ -104,6 +104,7 @@ class LammpsParser(object):
 
             for line in data_lines:
                 if line.strip():
+                    line = line.partition('#')[0] # Remove trailing comment
                     # catch all box dimensions
                     if (('xlo' in line) and
                          ('xhi' in line)):
@@ -130,7 +131,7 @@ class LammpsParser(object):
         with open(data_file, 'r') as data_lines:
             for line in data_lines:
                 if line.strip():
-                    keyword = line.strip()
+                    keyword = line.partition('#')[0].strip()
                     if keyword in parsable_keywords:
                         parsable_keywords[keyword](data_lines)
 
@@ -285,7 +286,7 @@ class LammpsParser(object):
         for line in data_lines:
             if not line.strip():
                 break  # found another blank line
-            fields = line.split()
+            fields = line.partition('#')[0].split()
             self.mass_dict[int(fields[0])] = float(fields[1]) * self.MASS
 
     def parse_pair_coeffs(self, data_lines):
@@ -295,7 +296,7 @@ class LammpsParser(object):
         for line in data_lines:
             if not line.strip():
                 break  # found another blank line
-            fields = [float(field) for field in line.split()]
+            fields = [float(field) for field in line.partition('#')[0].split()]
             if len(self.pair_style) == 1:
                 # TODO: lookup of type of pairstyle to determine format
                 if System._sys.nonbonded_function == 1:
@@ -313,7 +314,7 @@ class LammpsParser(object):
         for line in data_lines:
             if not line.strip():
                 break  # found another blank line
-            fields = line.split()
+            fields = line.partition('#')[0].split()
             if len(self.bond_style) == 1:
                 if 'harmonic' in self.bond_style:
                     self.bond_types[int(fields[0])] = [
@@ -352,7 +353,7 @@ class LammpsParser(object):
         for line in data_lines:
             if not line.strip():
                 break  # found another blank line
-            fields = line.split()
+            fields = line.partition('#')[0].split()
             if len(self.angle_style) == 1:
                 if 'harmonic' in self.angle_style:
                     self.angle_types[int(fields[0])] = [
@@ -379,7 +380,7 @@ class LammpsParser(object):
         for line in data_lines:
             if not line.strip():
                 break  # found another blank line
-            fields = line.split()
+            fields = line.partition('#')[0].split()
             if len(self.dihedral_style) == 1:
                 if 'opls' in self.dihedral_style:
                     self.dihedral_types[int(fields[0])] = [
@@ -410,7 +411,7 @@ class LammpsParser(object):
         for line in data_lines:
             if not line.strip():
                 break  # found another blank line
-            fields = line.split()
+            fields = line.partition('#')[0].split()
             if len(self.improper_style) == 1:
                 if 'harmonic' in self.improper_style:
                     self.improper_types[int(fields[0])] = [
@@ -436,7 +437,7 @@ class LammpsParser(object):
         for line in data_lines:
             if not line.strip():
                 break  # found another blank line
-            fields = line.split()
+            fields = line.partition('#')[0].split()
 
             if len(fields) in [7, 10]:
                 if len(fields) == 10:
@@ -488,7 +489,7 @@ class LammpsParser(object):
         for line in data_lines:
             if not line.strip():
                 break  # found another blank line
-            fields = [int(field) for field in line.split()]
+            fields = [int(field) for field in line.partition('#')[0].split()]
 
             new_bond_force = None
             coeff_num = int(fields[1])
@@ -515,7 +516,7 @@ class LammpsParser(object):
         for line in data_lines:
             if not line.strip():
                 break  # found another blank line
-            fields = [int(field) for field in line.split()]
+            fields = [int(field) for field in line.partition('#')[0].split()]
 
             new_angle_force = None
             coeff_num = int(fields[1])
@@ -534,7 +535,7 @@ class LammpsParser(object):
         for line in data_lines:
             if not line.strip():
                 break  # found another blank line
-            fields = [int(field) for field in line.split()]
+            fields = [int(field) for field in line.partition('#')[0].split()]
 
             new_dihed_force = None
             coeff_num = int(fields[1])
@@ -555,7 +556,7 @@ class LammpsParser(object):
         for line in data_lines:
             if not line.strip():
                 break  # found another blank line
-            fields = [int(field) for field in line.split()]
+            fields = [int(field) for field in line.partition('#')[0].split()]
 
             new_dihed_force = None
             coeff_num = int(fields[1])

--- a/testing/convert.py
+++ b/testing/convert.py
@@ -152,8 +152,7 @@ def main(args=None):
                     'inputs/Gromacs/grompp.mdp', args.gropath, '')
         elif args.lmp_in:
             input_type = 'Lammps'
-            # TODO: fix this when --lmp_in gets changed to read input files
-            temp = args.lmp_in[0].split('.')[0] + '.input'
+            temp = args.lmp_in[0]
             e_in, e_infile = lammps_driver.lammps_energies(temp, args.lmppath)
         else:
             logger.warn('Something weird went wrong! Code should have never made it here.')

--- a/testing/lammps_driver.py
+++ b/testing/lammps_driver.py
@@ -57,12 +57,12 @@ def lammps_energies(input_file, lmppath='lmp_openmpi'):
     data = [value * units.kilocalories_per_mole for value in data]
 
     # pack it all up in a dictionary
-    types = ['Bond', 'Angle', 'Proper Dih.', 'Improper', 'Non-bonded',
+    types = ['Bond', 'Angle', 'Proper Dih.', 'Improper Dih.', 'Non-bonded',
             'Dispersive', 'Electrostatic', 'Coul. recip.', 'Disper. corr.',
             'Potential']
     e_out = dict(zip(types, data))
 
     # groupings
     e_out['Electrostatic'] += e_out['Coul. recip.']
-    e_out['All dihedrals'] = e_out['Proper Dih.'] + e_out['Improper']
+    e_out['All dihedrals'] = e_out['Proper Dih.'] + e_out['Improper Dih.']
     return e_out, '%s/lammps_stdout.txt' % directory

--- a/testing/lammps_driver.py
+++ b/testing/lammps_driver.py
@@ -28,7 +28,7 @@ def lammps_energies(input_file, lmppath='lmp_openmpi'):
     """
     logger.info('Evaluating energy of {0}'.format(input_file))
 
-    directory, input_file = os.path.split(input_file)
+    directory, input_file = os.path.split(os.path.abspath(input_file))
 
     # mdrunin'
     saved_path = os.getcwd()


### PR DESCRIPTION
I made some changes mainly geared toward conversion from LAMMPS to GROMACS. Key changes include the following:
- Read/write multiple molecules/molecule types in lammps_parser.py. Unique molecule types are detected using the (not rigorous but usually sufficient) method employed in the TopoTools VMD plugin (see topogromacs.tcl).
- Infer 1-4 interactions topologically to properly generate [ pairs ] in GROMACS topologies.
- Detect rigid 3-site waters and define SETTLE constraints.
- Add support for reading additional dihedral styles (fourier, multi/harmonic) and improper styles (cvff).
