### PR TITLE
Develop: Generate 1-4 pair interactions in lammps_parser

### DIFF
--- a/intermol/gromacs/grofile_parser.py
+++ b/intermol/gromacs/grofile_parser.py
@@ -91,7 +91,7 @@ class GromacsGroParser(object):
                 if atom.name.isdigit():
                     # Kluge for atoms read in from a LAMMPS data file.
                     atom.name = "LMP_{0}".format(atom.name)
-                gro.write('{0:5d}{1:<4s}{2:6s}{3:5d}'.format(
+                gro.write('{0:5d}{1:<5s}{2:5s}{3:5d}'.format(
                         atom.residue_index, atom.residue_name, atom.name, n + 1))
                 for pos in atom.position:
                     gro.write('{0:17.12f}'.format(pos.value_in_unit(nanometers)))

--- a/intermol/lammps/lammps_driver.py
+++ b/intermol/lammps/lammps_driver.py
@@ -8,10 +8,10 @@ from intermol.lammps.lammps_parser import load_lammps, write_lammps
 logger = logging.getLogger('InterMolLog')
 
 def read_file(in_file):
-    logger.error('Not implemented yet!')
-    #logger.info('Reading LAMMPS files {0}'.format(infile))
-    #system = load_lammps(data_file, in_file)
-    #logger.info('...loaded.')
+    logger.info('Reading LAMMPS files {0}'.format(in_file))
+    system = load_lammps(in_file)
+    logger.info('...loaded.')
+    return system
 
 
 def write_file(in_file, system, unit_set='real'):

--- a/intermol/lammps/lammps_parser.py
+++ b/intermol/lammps/lammps_parser.py
@@ -295,14 +295,15 @@ class LammpsParser(object):
     def read(self):
         """Reads a LAMMPS input file and a data file specified within.
 
-        Args:
-            input_file (str): Name of LAMMPS input file to read in.
+        Returns:
+            system:
         """
-        self.read_input(self.in_file)
+        self.read_input()
         if self.data_file:
             self.read_data(self.data_file)
         else:
             raise Exception("No data file found in input script")
+        return self.system
 
     def read_input(self):
         """Reads a LAMMPS input file.
@@ -349,7 +350,7 @@ class LammpsParser(object):
                     keyword = line.split()[0]
                     if keyword in parsable_keywords:
                         parsable_keywords[keyword](line.split())
-            keyword_check[keyword] = True
+                        keyword_check[keyword] = True
 
         for key in keyword_check.keys():
             if not (keyword_check[key]):

--- a/intermol/lammps/lammps_parser.py
+++ b/intermol/lammps/lammps_parser.py
@@ -389,6 +389,8 @@ class LammpsParser(object):
 
             for line in data_lines:
                 if line.strip():
+                    # Remove trailing comment
+                    line = line.partition('#')[0]
                     # Catch all box dimensions.
                     if ('xlo' in line) and ('xhi' in line):
                         self.parse_box(line.split(), 0)
@@ -413,7 +415,7 @@ class LammpsParser(object):
         with open(data_file, 'r') as data_lines:
             for line in data_lines:
                 if line.strip():
-                    keyword = line.strip()
+                    keyword = line.partition('#')[0].strip()
                     if keyword in parsable_keywords:
                         parsable_keywords[keyword](data_lines)
 
@@ -540,10 +542,9 @@ class LammpsParser(object):
         fields = [float(field) for field in line[:2]]
         box_length = fields[1] - fields[0]
         if box_length > 0:
-            self.box_vector[dim, dim] = box_length
+            self.system.box_vector[dim, dim] = box_length * self.DIST
         else:
             raise ValueError("Negative box length specified in data file.")
-        self.system.box_vector = self.box_vector * self.DIST
 
     def parse_masses(self, data_lines):
         """Read masses from data file."""
@@ -552,7 +553,7 @@ class LammpsParser(object):
         for line in data_lines:
             if not line.strip():
                 break  # found another blank line
-            fields = line.split()
+            fields = line.partition('#')[0].split()
             self.mass_dict[int(fields[0])] = float(fields[1]) * self.MASS
 
     def parse_pair_coeffs(self, data_lines):
@@ -562,7 +563,7 @@ class LammpsParser(object):
         for line in data_lines:
             if not line.strip():
                 break  # found another blank line
-            fields = [float(field) for field in line.split()]
+            fields = [float(field) for field in line.partition('#')[0].split()]
             if len(self.pair_style) == 1:
                 # TODO: lookup of type of pairstyle to determine format
                 if self.system.nonbonded_function == 1:
@@ -582,7 +583,7 @@ class LammpsParser(object):
         for line in data_lines:
             if not line.strip():
                 break  # found another blank line
-            fields = line.split()
+            fields = line.partition('#')[0].split()
 
             warn = False
             if len(force_style) == 1:
@@ -659,7 +660,7 @@ class LammpsParser(object):
         for line in data_lines:
             if not line.strip():
                 break  # found another blank line
-            fields = line.split()
+            fields = line.partition('#')[0].split()
 
             if len(fields) in [7, 10]:
                 if len(fields) == 10:
@@ -719,7 +720,7 @@ class LammpsParser(object):
         for line in data_lines:
             if not line.strip():
                 break
-            fields = [field for field in line.split()]
+            fields = [field for field in line.partition('#')[0].split()]
             vel_dict[int(fields[0])] = fields[1:4]
         for atom in atoms:
             atom._velocity = [float(vel) * self.VEL for vel in
@@ -731,7 +732,7 @@ class LammpsParser(object):
         for line in data_lines:
             if not line.strip():
                 break  # found another blank line
-            fields = [int(field) for field in line.split()]
+            fields = [int(field) for field in line.partition('#')[0].split()]
 
             new_force = None
             coeff_num = fields[1]

--- a/intermol/lammps/lammps_parser.py
+++ b/intermol/lammps/lammps_parser.py
@@ -736,19 +736,19 @@ class LammpsParser(object):
 
     def parse_bonds(self, data_lines):
         self.parse_force(data_lines, self.bond_classes,
-                         self.current_mol_type.bondForceSet, n=2)
+                         self.current_mol_type.bond_forces, n=2)
 
     def parse_angles(self, data_lines):
         self.parse_force(data_lines, self.angle_classes,
-                         self.current_mol_type.angleForceSet, n=3)
+                         self.current_mol_type.angle_forces, n=3)
 
     def parse_dihedrals(self, data_lines):
         self.parse_force(data_lines, self.dihedral_classes,
-                         self.current_mol_type.dihedralForceSet, n=4)
+                         self.current_mol_type.dihedral_forces, n=4)
 
     def parse_impropers(self, data_lines):
         self.parse_force(data_lines, self.improper_classes,
-                         self.current_mol_type.dihedralForceSet, n=4)
+                         self.current_mol_type.dihedral_forces, n=4)
 
     def get_force_atoms(self, force, forceclass):
         """Return the atoms involved in a force. """

--- a/intermol/lammps/lammps_parser.py
+++ b/intermol/lammps/lammps_parser.py
@@ -652,7 +652,7 @@ class LammpsParser(object):
         self.improper_classes = dict()
         self.parse_force_coeffs(data_lines, "Improper",
                                 self.improper_classes, self.improper_style,
-                                self.lammps_impropers, self.canonical_improper)
+                                self.lammps_impropers, self.canonical_dihedral)
 
     def parse_atoms(self, data_lines):
         """Read atoms from data file."""

--- a/intermol/lammps/lammps_parser.py
+++ b/intermol/lammps/lammps_parser.py
@@ -379,10 +379,13 @@ class LammpsParser(object):
             self.molecule_name = next(data_lines).strip()
             # Currently only reading a single molecule/moleculeType
             # per LAMMPS file.
+            self.current_mol_type = MoleculeType(self.molecule_name)
+            self.current_mol_type.nrexcl = 3  # TODO: automate determination!
+            # NOTE: nrexcl is a global in lammps and should probably be 
+            # determined in parse_special_bonds
+            self.system.add_molecule_type(self.current_mol_type)
             self.current_mol = Molecule(self.molecule_name)
             self.system.add_molecule(self.current_mol)
-            self.current_mol_type = self.system._molecules[self.molecule_name]
-            self.current_mol_type.nrexcl = 3  # TODO: automate determination!
 
             for line in data_lines:
                 if line.strip():

--- a/intermol/system.py
+++ b/intermol/system.py
@@ -2,6 +2,7 @@ from collections import OrderedDict
 import logging
 
 import numpy as np
+import simtk.unit as units
 
 logger = logging.getLogger('InterMolLog')
 
@@ -26,7 +27,7 @@ class System(object):
         self.lj_correction = 0
         self.coulomb_correction = 0
 
-        self._box_vector = np.zeros([3, 3])
+        self._box_vector = np.zeros([3, 3]) * units.nanometers
 
         self._n_atoms = None
         self._molecule_types = OrderedDict()


### PR DESCRIPTION
Topologically infer 1-4 neighbors from set of bonds so that we can write [ pairs ] in GROMACS topologies. Other (minor) changes include stripping trailing comments in LAMMPS data files.