### PR TITLE
Fix for lammps unit tests

### DIFF
--- a/intermol/convert.py
+++ b/intermol/convert.py
@@ -118,7 +118,7 @@ def main(args=None):
 
         system = gromacs_driver.read_file(top_in, gro_in, gropath)
     elif args.get('lmp_in'):
-        lammps_file = args['lmp_in'][0]
+        lammps_file = args['lmp_in']
         prefix = os.path.splitext(os.path.basename(lammps_file))[0]
         system = lammps_driver.read_file(in_file=lammps_file)
     elif args.get('des_in'):

--- a/intermol/desmond/desmond_parser.py
+++ b/intermol/desmond/desmond_parser.py
@@ -223,7 +223,7 @@ class DesmondParser(object):
                     if matched_angle and matched_angle.__class__ == UreyBradleyAngle:
                         angle.r = matched_angle.r
                         angle.kUB = matched_angle.kUB
-                        molecule_type.angle.forces.remove(matched_angle)
+                        molecule_type.angle_forces.remove(matched_angle)
             elif direction == 'from' and angle.__class__ in [UreyBradleyAngle]:
                 params_harmpart = {k:v for (k,v) in params.items() if k in ['theta','k','c'] }
                 names.append(name)

--- a/intermol/forces/__init__.py
+++ b/intermol/forces/__init__.py
@@ -10,6 +10,8 @@ from intermol.forces.atom_sigeps_type import AtomSigepsType
 
 from intermol.forces.settles import Settles
 
+from intermol.forces.torsion_torsion_cmap import TorsionTorsionCMAP
+
 # what is below here really should be written automatically
 # nonbonded
 # don't think we use the functions, just the types?


### PR DESCRIPTION
When running test_lammps -t unit, only one lammps input file
gets passed at a time, hence args['lmp_in'] only pulls the first
character in this file.