### PR TITLE
Wrong desmond extension in energy run.

### DIFF
--- a/intermol/convert.py
+++ b/intermol/convert.py
@@ -228,7 +228,7 @@ def main(args=None):
             output_type.append('desmond')
             try:
                 out, outfile = desmond_driver.desmond_energies(
-                    '{0}.input'.format(oname), cfg_path, despath)
+                    '{0}.cms'.format(oname), cfg_path, despath)
             except Exception as e:
                 output_status['desmond'] = e
                 logger.exception(e)

--- a/intermol/desmond/desmond_parser.py
+++ b/intermol/desmond/desmond_parser.py
@@ -301,13 +301,12 @@ class DesmondParser(object):
             else:
                 names = []
                 paramlists = []
-                if dihedral in [ImproperHarmonicDihedral]:
+
+                if dihedral.__class__ in [ImproperHarmonicDihedral]:
                     params['k'] = params['k'] * canonical_force_scale
                     name = 'IMPROPER_HARM'
-                    names.append(name)
-                    params.append(params)
 
-                elif dihedral in [TrigDihedral]:
+                elif dihedral.__class__ in [TrigDihedral]:
                     optkwds = ff.optparamlookup(dihedral.__class__)
                     if optkwds['improper']:
                         name = 'IMPROPER_TRIG'

--- a/intermol/desmond/desmond_parser.py
+++ b/intermol/desmond/desmond_parser.py
@@ -1255,7 +1255,7 @@ class DesmondParser(object):
                 bond_params = self.get_parameter_list_from_force(converted_bond)
                 param_units = self.unitvars[converted_bond.__class__.__name__]
                 for param, param_unit in zip(bond_params, param_units):
-                    line += "%15.8f" % (param.value_in_unit(param_unit))
+                    line += " %15.8f" % (param.value_in_unit(param_unit))
                 line += '\n'
                 dlines.append(line)
         header = "    ffio_bonds[%d] {\n" % (i)
@@ -1295,7 +1295,7 @@ class DesmondParser(object):
                 angle_params = self.get_parameter_list_from_force(converted_angle)
                 param_units = self.unitvars[converted_angle.__class__.__name__]
                 for param, param_unit in zip(angle_params, param_units):
-                    line += "%15.8f" % (param.value_in_unit(param_unit))
+                    line += " %15.8f" % (param.value_in_unit(param_unit))
                 line += '\n'
                 dlines.append(line)
 
@@ -1341,9 +1341,9 @@ class DesmondParser(object):
                 dihedral_params = self.get_parameter_list_from_force(converted_dihedral)
                 param_units = self.unitvars[converted_dihedral.__class__.__name__]
                 for param, param_unit in zip(dihedral_params, param_units):
-                    line += "%15.8f" % (param.value_in_unit(param_unit))
+                    line += " %15.8f" % (param.value_in_unit(param_unit))
                 for j in range(8-len(dihedral_params)):
-                    line += "%6.3f" % (0.0)
+                    line += " %6.3f" % (0.0)
                 line += '\n'
                 dlines.append(line)
 


### PR DESCRIPTION
should be cms instead of input.  

Took me surprisingly long to realize the wrong file was being passed in . . . 