### PR TITLE
Fix py3 "Exception ignored in"

### DIFF
--- a/intermol/orderedset.py
+++ b/intermol/orderedset.py
@@ -41,10 +41,6 @@ class OrderedSet(collections.Set):
                 return False
         return True
 
-    ### General Methods
-    def __del__(self):
-        self.d.clear()                    # remove circular labels
-
     def __repr__(self):
         class_name = self.__class__.__name__
         if not self:


### PR DESCRIPTION
This happens due to errors during garbage collection. This has a bit more info:
http://stackoverflow.com/questions/18637048/avoid-exception-ignored-in-python-enhanced-generator