### PR TITLE
Fix lmp_in and des_in being passed as lists.

### DIFF
--- a/intermol/convert.py
+++ b/intermol/convert.py
@@ -25,11 +25,11 @@ def parse_args(args):
 
     # Input arguments.
     group_in = parser.add_argument_group('Choose input conversion format')
-    group_in.add_argument('--des_in', nargs=1, metavar='file',
+    group_in.add_argument('--des_in', metavar='file',
             help='.cms file for conversion from DESMOND file format')
     group_in.add_argument('--gro_in', nargs=2, metavar='file',
             help='.gro and .top file for conversion from GROMACS file format')
-    group_in.add_argument('--lmp_in', nargs=1, metavar='file',
+    group_in.add_argument('--lmp_in', metavar='file',
             help='input file for conversion from LAMMPS file format (expects'
                  ' data file in same directory and a read_data call)')
 


### PR DESCRIPTION
@mrshirts can you confirm that this was an issue for you too and that this fixes it?

Not sure how this wasn't noticed before but `lmp_in` and `des_in` were passed as lists when using `convert.py` directly but not when using `test_all.py`. This should make the behavior consistent.