### PR TITLE
Print LAMMPS UB angles as float

### DIFF
--- a/intermol/convert.py
+++ b/intermol/convert.py
@@ -15,8 +15,11 @@ import intermol.charmm as crm
 import intermol.tests
 
 # we have a number of "canonical" terms that we would like to print first
-canonical_keys = ['Potential', 'Bond', 'Angle', 'All dihedrals', 'LJ-14', 'Coulomb-14', 
-                  'van der Waals', 'Electrostatic', 'Bonded', 'Nonbonded']
+canonical_keys = ['Potential',
+                  'Bonded', 'Nonbonded',
+                  'van der Waals', 'Electrostatic',
+                  'Bond', 'Angle', 'All angles', 'All dihedrals',
+                  'LJ-14', 'Coulomb-14']
 # Make a global logging object.
 logger = logging.getLogger('InterMolLog')
 logger.setLevel(logging.DEBUG)

--- a/intermol/gromacs/__init__.py
+++ b/intermol/gromacs/__init__.py
@@ -137,8 +137,13 @@ def _group_energy_terms(ener_xvg):
 
     e_out['Non-bonded'] = e_out['Electrostatic'] + e_out['Dispersive']
 
-    # All the various dihedral energies.
-    # TODO: What else goes in here?
+    all_angles = ['Angle', 'U-B', 'G96Angle', 'Restricted Angles', 'Bond-Cross',
+                  'BA-Cross', 'Quartic Angles']
+    e_out['All angles'] = 0 * units.kilojoules_per_mole
+    for group in all_angles:
+        if group in e_out:
+            e_out['All angles'] += e_out[group]
+
     all_dihedrals = ['Ryckaert-Bell.', 'Proper Dih.', 'Improper Dih.']
     e_out['All dihedrals'] = 0 * units.kilojoules_per_mole
     for group in all_dihedrals:

--- a/intermol/lammps/__init__.py
+++ b/intermol/lammps/__init__.py
@@ -81,4 +81,5 @@ def _group_energy_terms(stdout_path):
 
     e_out['Electrostatic'] += e_out['Coul. recip.']
     e_out['All dihedrals'] = e_out['Proper Dih.'] + e_out['Improper']
+    e_out['All angles'] = e_out['Angle']
     return e_out, stdout_path

--- a/intermol/lammps/lammps_parser.py
+++ b/intermol/lammps/lammps_parser.py
@@ -896,8 +896,11 @@ class LammpsParser(object):
                             # LAMMPS expects an integer.
                             line += "%10d" % (p.value_in_unit(u[i]))
                         elif style == 'charmm' and p.unit == units.degrees:
-                            # LAMMPS loves enforcing unnecessary integers.
-                            line += "%10d" % (p.value_in_unit(u[i]))
+                            if force_name == 'Dihedral':
+                                # LAMMPS loves enforcing unnecessary integers.
+                                line += "%10d" % (p.value_in_unit(u[i]))
+                            else:
+                                line += "%18.8e" % (p.value_in_unit(u[i]))
                         else:
                             line += "%18.8e" % (p.value_in_unit(u[i]))
                     line += '\n'


### PR DESCRIPTION
LAMMPS appears to enforce integers for charmm style dihedral angles but
not the UB terms.

Also adds a group summarizing all angle energies to the output table for
GROMACS and LAMMPS.

TODO: proper angle summaries for other parsers