### PR TITLE
newlines in the -ls option are not passed through (#315)

### DIFF
--- a/intermol/lammps/lammps_parser.py
+++ b/intermol/lammps/lammps_parser.py
@@ -1208,7 +1208,7 @@ class LammpsParser(object):
             f.write('\n')
 
             # non-bonded: either defaults, or specified by user
-            f.write(nonbonded_style)
+            f.write(nonbonded_style.replace('[lf]',os.linesep))
 
             for line in pair_coeffs:
                 f.write(line)


### PR DESCRIPTION
This works for me:
```bash
$ python /home/maaren/git/maaren/InterMol/intermol/convert.py --gropath /home/maaren/bin/ --gro_in 1-butanol_T298.15_1mol.gro 1-butanol_1mol.top --inefile mdin.mdp --lammps --odir ./ -ls 'pair_style lj/cut/coul/long 15.0 15.0[lf]pair_modify tail yes[lf]kspace_style pppm 1e-8[lf][lf]'
$ less 1-butanol_T298.15_1mol_converted.input
...
read_data 1-butanol_T298.15_1mol_converted.lmp

pair_style lj/cut/coul/long 15.0 15.0
pair_modify tail yes
kspace_style pppm 1e-8

pair_coeff 1 1   0.0660000   3.5000000
pair_coeff 2 2   0.0300000   2.5000000
...
```