### PR TITLE
Set coefficients to 0 if they were missing from input file, this is a…

### DIFF
--- a/intermol/forces/forcefunctions.py
+++ b/intermol/forces/forcefunctions.py
@@ -136,7 +136,10 @@ def create_kwds_from_entries(unitvars, paramlist, entries, force_type, offset=0)
     u = unitvars[typename]
     params = paramlist[typename]
     for i, p in enumerate(params):
-        kwds[p] = float(entries[offset+i]) * u[i]
+        if len(entries)<=(offset+i):
+            kwds[p] = float(0.0)
+        else:
+            kwds[p] = float(entries[offset+i]) * u[i]
     return kwds
 
 


### PR DESCRIPTION
… result of addressing error where dihedral angle expected five coefficients but only four were provided. This is to address this issue:

https://github.com/shirtsgroup/InterMol/issues/348