### PR TITLE
Add convert.py alias to $PATH

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,5 +69,10 @@ setup(
         'Topic :: Scientific/Engineering :: Chemistry',
         'Topic :: Software Development :: Libraries :: Python Modules'
         ],
+    entry_points={
+        'console_scripts': [
+            'intermol-convert=intermol.convert:main',
+        ],
+    },
 )
 


### PR DESCRIPTION
Thought about this as a small patch while working on a separate project. Can be named anything; this is the simplest way to expose the conversion function without a heavy refactor. Other commands can be added, but it looks like this is pretty much the only file that a user would access directly.

This automatically adds the command `intermol-convert` to the user's $PATH if locally installed with pip; having it automagically work in a conda install can be done if/when there's another release.

```
(openff-dev) [InterMol] python -m pip install -e .
Obtaining file:///Users/mwt/software/InterMol
Requirement already satisfied: numpy in /Users/mwt/miniconda3/envs/openff-dev/lib/python3.7/site-packages (from intermol==0.1.0) (1.19.4)
Requirement already satisfied: parmed in /Users/mwt/miniconda3/envs/openff-dev/lib/python3.7/site-packages (from intermol==0.1.0) (at20RC5-54.g5702a232fe.dirty)
Requirement already satisfied: six in /Users/mwt/miniconda3/envs/openff-dev/lib/python3.7/site-packages (from intermol==0.1.0) (1.15.0)
Installing collected packages: intermol
  Attempting uninstall: intermol
    Found existing installation: intermol 0.1.0
    Uninstalling intermol-0.1.0:
      Successfully uninstalled intermol-0.1.0
  Running setup.py develop for intermol
Successfully installed intermol
(openff-dev) [InterMol] intermol-convert --help  # same output as python intermol/convert.py --help
usage: intermol-convert [-h] [--des_in file] [--gro_in file file]
                        [--lmp_in file] [--amb_in file file] [--crm_in file]
                        [--desmond] [--gromacs] [--lammps] [--amber]
                        [--charmm] [--odir directory] [--oname prefix] [-e]
                        [--inefile INEFILE] [-dp path] [-ds settings]
                        [-gp path] [-gs settings] [-lp path] [-ls settings]
                        [-ap path] [-as settings] [-cp path] [-cs settings]
                        [-f] [-v] [-n]

Perform a file conversion

optional arguments:
  -h, --help            show this help message and exit

Choose input conversion format:
  --des_in file         .cms file for conversion from DESMOND file format
  --gro_in file file    .gro and .top file for conversion from GROMACS file
                        format
  --lmp_in file         input file for conversion from LAMMPS file format
                        (expects data file in same directory and a read_data
                        call)
  --amb_in file file    input files (.prmtop) and (.crd or equivalent) for
                        conversion from AMBER file format
  --crm_in file         input file for conversion from CHARMM file format

Choose output conversion format(s):
  --desmond             convert to DESMOND
  --gromacs             convert to GROMACS
  --lammps              convert to LAMMPS
  --amber               convert to AMBER
  --charmm              convert to CHARMM

Other optional arguments:
  --odir directory      specification of output directory (default: ./)
  --oname prefix        specification of prefix for output filenames (default:
                        inputprefix_converted)
  -e, --energy          evaluate energy of input and output files for
                        comparison
  --inefile INEFILE     optional run settings file for input energy evaluation
                        (e.g. .cfg, .mdp, .input)
  -dp path, --despath path
                        path for DESMOND binary, needed for energy evaluation
  -ds settings, --desmondsettings settings
                        Desmond .cfg settings file used for energy evaluation
  -gp path, --gropath path
                        path for GROMACS binary, needed for energy evaluation
  -gs settings, --gromacssettings settings
                        Gromacs .mdp settings file used for energy evaluation
  -lp path, --lmppath path
                        path for LAMMPS binary, needed for energy evaluation
  -ls settings, --lammpssettings settings
                        pair_style string to use in the output file. Default
                        is a periodic Ewald simulation
  -ap path, --amberpath path
                        path for AMBER binary, needed for energy evaluation
  -as settings, --ambersettings settings
                        AMBER .in file used for energy evaluation
  -cp path, --charmmpath path
                        path for CHARMM binary, needed for energy evaluation
  -cs settings, --charmmsettings settings
                        CHARMM .in settings used for energy evaluation.
                        Because of the unified input file, settings lines
                        rather than a file are part
  -f, --force           ignore warnings (NOTE: may lead to partially correct
                        topologies)
  -v, --verbose         high verbosity, includes DEBUG level output
  -n, --noncanonical    print the 'noncanonical' enery terms, the ones that
                        only occur in 1 or 2 programs
```
