### PR TITLE
Add long_description_content_type

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     cmdclass=versioneer.get_cmdclass(),
     description=short_description,
     long_description=long_description,
+    long_description_content_type='text/markdown',
     author='Christoph Klein, Christopher Lee, Ellen Zhong, and Michael Shirts',
     author_email='ctk3b@virginia.edu, ctl4f@virginia.edu, edz3fz@virginia.edu, '
                  'michael.shirts@virginia.edu',


### PR DESCRIPTION
We have been asked to install InterMol in NMRbox (nmrbox.org). It's easiest for us to install Python packages that are in the pypi.org repo. This change tells pypi how to render the README.md

Example: https://test.pypi.org/project/intermol/1.0/