### PR TITLE
Add versioneer as a build-time dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,10 @@ trj
 ehthumbs.db
 Thumbs.db
 
-# python #
-*.pyc
+# Python
+__pycache__/
+*.py[cod]
+
+# Distribution / packaging
+dist/
+*.egg-info/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "versioneer[toml]"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
I needed to add this to get `python3 -m build` to work, since it doesn't seem to process down the local file as a module - or something like that. It seems to be a common issue.

https://twine.readthedocs.io/en/stable/#using-twine
https://github.com/python-versioneer/python-versioneer#build-time-dependency-mode

Log without:

```console
$ git checkout v0.1.2 && python3 -m build                           11:18:55  ☁  8d77a4f ☀
HEAD is now at 8d77a4f Update package setup (#389)
* Creating virtualenv isolated environment...
<SNIP>
* Getting build dependencies for wheel...
Traceback (most recent call last):
  File "/Users/mattthompson/mambaforge/envs/openff-interchange-env/lib/python3.9/site-packages/pep517/in_process/_in_process.py", line 351, in <module>
    main()
  File "/Users/mattthompson/mambaforge/envs/openff-interchange-env/lib/python3.9/site-packages/pep517/in_process/_in_process.py", line 333, in main
    json_out['return_val'] = hook(**hook_input['kwargs'])
  File "/Users/mattthompson/mambaforge/envs/openff-interchange-env/lib/python3.9/site-packages/pep517/in_process/_in_process.py", line 118, in get_requires_for_build_wheel
    return hook(config_settings)
  File "/private/var/folders/p1/176rcfkn6zlbbjq4bdjmv2pr0000gn/T/build-env-aawxa0b3/lib/python3.9/site-packages/setuptools/build_meta.py", line 338, in get_requires_for_build_wheel
    return self._get_build_requires(config_settings, requirements=['wheel'])
  File "/private/var/folders/p1/176rcfkn6zlbbjq4bdjmv2pr0000gn/T/build-env-aawxa0b3/lib/python3.9/site-packages/setuptools/build_meta.py", line 320, in _get_build_requires
    self.run_setup()
  File "/private/var/folders/p1/176rcfkn6zlbbjq4bdjmv2pr0000gn/T/build-env-aawxa0b3/lib/python3.9/site-packages/setuptools/build_meta.py", line 484, in run_setup
    super(_BuildMetaLegacyBackend,
  File "/private/var/folders/p1/176rcfkn6zlbbjq4bdjmv2pr0000gn/T/build-env-aawxa0b3/lib/python3.9/site-packages/setuptools/build_meta.py", line 335, in run_setup
    exec(code, locals())
  File "<string>", line 5, in <module>
ModuleNotFoundError: No module named 'versioneer'

ERROR Backend subprocess exited when trying to invoke get_requires_for_build_wheel

```
This branch builds with pages of log ending in
```console
removing build/bdist.macosx-10.9-x86_64/wheel
Successfully built intermol-0.0.0+16.ge78e95d.tar.gz and intermol-0.0.0+16.ge78e95d-py3-none-any.whl