### PR TITLE
Report GROMACS Per. Imp. Dih. energy contribution

### DIFF
--- a/intermol/gromacs/__init__.py
+++ b/intermol/gromacs/__init__.py
@@ -26,6 +26,7 @@ to_canonical = {
     'Proper Dih.': ['dihedral', 'proper'],
     'Ryckaert-Bell.': ['dihedral', 'proper'],
     'Improper Dih.': ['dihedral', 'improper'],
+    'Per. Imp. Dih.': ['dihedral', 'improper'],
     'CMAP': ['dihedral','cmap'],
     'LJ (SR)': ['vdw total', 'vdw (SR)'],
     'LJ-14': ['vdw total','vdw-14'],


### PR DESCRIPTION
The GROMACS dihedral type 4 (periodic improper dihedral, see table in https://manual.gromacs.org/documentation/2024.2/reference-manual/topologies/topology-file-formats.html and https://manual.gromacs.org/documentation/current/reference-manual/functions/bonded-interactions.html#improper-dihedrals-periodic-type) produces its own energy contribution named "Per. Imp. Dih." in the `energy.xvg`. The single line added in this PR would evaluate this contribution, but likely override the other "Improper Dih." energy contribution. What would be the desired way of reporting this energy contribution?

A standard InterMol GROMAC -> LAMMPS conversion energy report would look like this

```
Energy group summary
=======================================================================
                type     input(gromacs)   output (lammps)     diff (lammps)
-----------------------------------------------------------------------
Not comparable energies: are likely not to be the same
-----------------------------------------------------------------------
        coulomb (LR)       452.62161255        0.00000000     -452.62161255
        coulomb (SR)     -9485.61523438        0.00000000     9485.61523438
       coulomb total     -2830.31246948    13796.20026400    16626.51273348
          coulomb-14      6202.68115234        0.00000000    -6202.68115234
              proper      5090.43310547     5887.73274960      797.29964413
            vdw (LR)      -106.85102081     -107.06120453       -0.21018372
            vdw (SR)     -1337.50134277        0.00000000     1337.50134277
           vdw total      3378.27410126     3270.99533523     -107.27876603
              vdw-14      4822.62646484        0.00000000    -4822.62646484
-----------------------------------------------------------------------
Comparable energy terms: these should be very close
-----------------------------------------------------------------------
               angle      7595.20751953     7595.20683200       -0.00068753
                bond      1527.76965332     1527.77216104        0.00250772
              bonded     14213.41027832    15010.71174264      797.30146432
            dihedral      5090.43310547     5887.73274960      797.29964413
           nonbonded       547.96163177      548.64080720        0.67917543
           potential     15558.67675781    15559.35250800        0.67575019

---------------- Total Potential Energy Comparison --------------------
Input gromacs potential energy:         15558.67675781
Difference in potential energy from gromacs=>lammps conversion:         0.67575019
=======================================================================
```

while the report with this additional line looks like this,

```
=======================================================================
                type     input(gromacs)   output (lammps)     diff (lammps)
-----------------------------------------------------------------------
Not comparable energies: are likely not to be the same
-----------------------------------------------------------------------
        coulomb (LR)       452.62170410        0.00000000     -452.62170410
        coulomb (SR)     -9485.61523438        0.00000000     9485.61523438
       coulomb total     -2830.31237793    13796.20026400    16626.51264193
          coulomb-14      6202.68115234        0.00000000    -6202.68115234
            improper       797.30468750        0.00000000     -797.30468750
              proper      5090.43310547     5887.73274960      797.29964413
            vdw (LR)      -106.85102081     -107.06120453       -0.21018372
            vdw (SR)     -1337.50134277        0.00000000     1337.50134277
           vdw total      3378.27410126     3270.99533523     -107.27876603
              vdw-14      4822.62646484        0.00000000    -4822.62646484
-----------------------------------------------------------------------
Comparable energy terms: these should be very close
-----------------------------------------------------------------------
               angle      7595.20751953     7595.20683200       -0.00068753
                bond      1527.76965332     1527.77216104        0.00250772
              bonded     15010.71496582    15010.71174264       -0.00322318
            dihedral      5887.73779297     5887.73274960       -0.00504337
           nonbonded       547.96172333      548.64080720        0.67908387
           potential     15558.67675781    15559.35250800        0.67575019

---------------- Total Potential Energy Comparison --------------------
Input gromacs potential energy:         15558.67675781
Difference in potential energy from gromacs=>lammps conversion:         0.67575019
=======================================================================
```

You see that the GROMACS `proper` + `improper` contributions now add up to the LAMMPS `proper` dihedral contribution. This is expected as InterMol converts GROMACS type 4 periodic improper dihedrals to LAMMPS multi/nharmonic proper dihedrals.